### PR TITLE
Make ./run a symlink to ./run.sh

### DIFF
--- a/run
+++ b/run
@@ -1,1 +1,1 @@
-qemu-system-i386 -fda build/main_floppy.img
+run.sh


### PR DESCRIPTION
Basically, as ./run and ./run.sh have the same content, making ./run a symlink to ./run.sh would be, in my opinion, the best thing to do